### PR TITLE
Makefile: make all means all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LDFLAGS += $(shell pkg-config --libs json-c)
 .dvi.txt:
 	dvi2tty -w 132 $< > $*.txt
 
-all: libproto.a librfs.a $(UTIL) celemp galcreat turn trans edit celemp.pdf celemp.txt admin.pdf admin.txt
+all: libproto.a librfs.a $(UTIL) celemp galcreat turn trans edit texproc celemp.pdf celemp.txt admin.pdf admin.txt
 
 everything: all dox admin src 
 


### PR DESCRIPTION
Currently, the `make all` target is not building all: in particular,
it is not building texproc, which means that a `make all` on a clean
tree will fail unless it is preceded by a `make texproc`.

This patch fixes this by including texproc as one of the targets for
`make all`.

Closes: #1